### PR TITLE
Add dev path with warning banner.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
           # Deploy to root for main
-          destination_dir: /
+          destination_dir: .
 
   deploy-dev:
     if: github.ref == 'refs/heads/dev'
@@ -60,4 +60,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
           # Deploy to /dev/ for the dev version
-          destination_dir: /dev
+          destination_dir: dev

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
+      - dev
 
 jobs:
-  deploy:
+  deploy-main:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
@@ -24,8 +26,38 @@ jobs:
         run: |
           mkdocs build
 
-      - name: Deploy to GitHub Pages
+      - name: Deploy main to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
+          # Deploy to root for main
+          destination_dir: /
+
+  deploy-dev:
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material
+
+      - name: Build docs
+        run: |
+          mkdocs build
+
+      - name: Deploy dev to GitHub Pages subdir
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          # Deploy to /dev/ for the dev version
+          destination_dir: /dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Web: Toggle for light/dark theme.
+- HTML override for main that adds styling and scripts to add a warning when viewing a page in the cmsg/dev path.
+
+### Changed
+- Edited mkdocs config to recognize overrides.
+- Modified actions workflow to have new job for pushes on dev and to generate a separate mkdocs based off the dev branch into dev/ on the gh-books branch.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,2 +1,3 @@
 # Hello World!
 This is filler text. Hi!
+I am on the dev branch!

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <style>
+    .dev-banner {
+      background-color: #ff0000;
+      color: white;
+      text-align: center;
+      font-weight: bold;
+      padding: 10px;
+      position: fixed;
+      top: 0;
+      width: 100%;
+      z-index: 1000;
+    }
+    body {
+      padding-top: 40px; /* Adjust this to match the banner height */
+    }
+  </style>
+  <script>
+    // Add a banner if the path contains 'dev'
+    if (window.location.pathname.includes('/dev/')) {
+      const banner = document.createElement('div');
+      banner.className = 'dev-banner';
+      banner.innerHTML = 'WARNING! - You are viewing the development version of this site. You should not use anything on this page unless you meant to be here. <a href="/">Click here</a> to go back to the main page.';
+      document.body.prepend(banner);
+    }
+  </script>
+{% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -19,6 +19,24 @@
     .dev-banner a {
       text-decoration: underline;
     }
+    body {
+      transition: padding-top 0.3s ease;
+    }
+    
+    #close-banner {
+      background-color: white;
+      color: black;
+      border: none;
+      border-radius: 20px;
+      padding: 5px 15px;
+      cursor: pointer;
+      font-weight: bold;
+      transition: background-color 0.3s ease;
+      margin-left: 15px;
+    }
+    #close-banner:hover {
+      background-color: #f0f0f0;
+    }
   </style>
   <script>
     window.addEventListener('DOMContentLoaded', (event) => {
@@ -27,7 +45,7 @@
         // Add warning banner.
         const banner = document.createElement('div');
         banner.className = 'dev-banner';
-        banner.innerHTML = 'WARNING! - You are viewing the development version of this site. You should not use anything on this page unless you meant to be here. <a href="/">Click here</a> to go back to the main page. <button onclick="this.parentElement.remove();">Close</button>';
+        banner.innerHTML = 'WARNING! - You are viewing the development version of this site. You should not use anything on this page unless you meant to be here. <a href="/cmsg">Click here</a> to go back to the main page. <button id="close-banner">Close</button>';
         document.body.prepend(banner);
 
         // Ajdust body padding based off dev warning above.
@@ -35,9 +53,14 @@
           const bannerHeight = banner.offsetHeight;
           document.body.style.paddingTop = `${bannerHeight}px`;
         };
-
         adjustBodyPadding();
+        //Adjust on resize.
         window.addEventListener('resize', adjustBodyPadding);
+        // Adjust on banner close.
+        document.getElementById('close-banner').addEventListener('click', () => {
+          banner.remove();  // Remove the banner
+          document.body.style.paddingTop = '0';  // Reset body padding
+        });
       }
     });
   </script>

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -23,12 +23,23 @@
     }
   </style>
   <script>
-    // Add a banner if the path contains 'dev'
-    if (window.location.pathname.includes('/dev/')) {
-      const banner = document.createElement('div');
-      banner.className = 'dev-banner';
-      banner.innerHTML = 'WARNING! - You are viewing the development version of this site. You should not use anything on this page unless you meant to be here. <a href="/">Click here</a> to go back to the main page.';
-      document.body.prepend(banner);
-    }
+    window.addEventListener('DOMContentLoaded', (event) => {
+      console.log('DOM fully loaded and parsed');
+      
+      // Check if the page is being served from the dev path
+      if (window.location.pathname.includes('/dev/')) {
+        console.log('Dev path detected. Adding banner...');
+        
+        const banner = document.createElement('div');
+        banner.className = 'dev-banner';
+        banner.innerHTML = 'WARNING! - You are viewing the development version of this site. You should not use anything on this page unless you meant to be here. <a href="/">Click here</a> to go back to the main page.';
+        // Add banner to the body
+        document.body.prepend(banner);
+        
+        console.log('Banner added to the DOM.');
+      } else {
+        console.log('Not on the dev path. No banner added.');
+      }
+    });
   </script>
 {% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -4,8 +4,8 @@
   {{ super() }}
   <style>
     .dev-banner {
-      background-color: #ff0000;
-      color: white;
+      background-color: #ff0000 !important;
+      color: white !important;
       text-align: center;
       font-weight: bold;
       padding: 10px;
@@ -13,9 +13,13 @@
       top: 0;
       width: 100%;
       z-index: 1000;
+      border-bottom: 2px solid black;
+    }
+    .dev-banner a {
+      text-decoration: underline;
     }
     body {
-      padding-top: 40px; /* Adjust this to match the banner height */
+      padding-top: 60px;
     }
   </style>
   <script>

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -7,6 +7,7 @@
       background-color: #ff0000 !important;
       color: white !important;
       text-align: center;
+      font-size: .8rem;
       font-weight: bold;
       padding: 10px;
       position: fixed;
@@ -18,27 +19,25 @@
     .dev-banner a {
       text-decoration: underline;
     }
-    body {
-      padding-top: 60px;
-    }
   </style>
   <script>
     window.addEventListener('DOMContentLoaded', (event) => {
-      console.log('DOM fully loaded and parsed');
-      
-      // Check if the page is being served from the dev path
+      // If on the dev site...
       if (window.location.pathname.includes('/dev/')) {
-        console.log('Dev path detected. Adding banner...');
-        
+        // Add warning banner.
         const banner = document.createElement('div');
         banner.className = 'dev-banner';
-        banner.innerHTML = 'WARNING! - You are viewing the development version of this site. You should not use anything on this page unless you meant to be here. <a href="/">Click here</a> to go back to the main page.';
-        // Add banner to the body
+        banner.innerHTML = 'WARNING! - You are viewing the development version of this site. You should not use anything on this page unless you meant to be here. <a href="/">Click here</a> to go back to the main page. <button onclick="this.parentElement.remove();">Close</button>';
         document.body.prepend(banner);
-        
-        console.log('Banner added to the DOM.');
-      } else {
-        console.log('Not on the dev path. No banner added.');
+
+        // Ajdust body padding based off dev warning above.
+        const adjustBodyPadding = () => {
+          const bannerHeight = banner.offsetHeight;
+          document.body.style.paddingTop = `${bannerHeight}px`;
+        };
+
+        adjustBodyPadding();
+        window.addEventListener('resize', adjustBodyPadding);
       }
     });
   </script>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: 'Complete Minecraft Server Guide'
 theme:
   name: 'material'
+  custom_dir: docs/overrides
   palette:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
### Added
- HTML override for main that adds styling and scripts to add a warning when viewing a page in the cmsg/dev path.

### Changed
- Edited mkdocs config to recognize overrides.
- Modified actions workflow to have new job for pushes on dev and to generate a separate mkdocs based off the dev branch into dev/ on the gh-books branch.